### PR TITLE
Add platformio library description file to integrate in platformio library management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# Adafruit VEML6070 
+Arduino Library for VEML6070 Digital UV sensors Breakout (https://www.adafruit.com/product/2899)
+
+More informations on how to use it is provided by Adafruit.
+
+https://learn.adafruit.com/adafruit-veml6070-uv-light-sensor-breakout/overview

--- a/library.json
+++ b/library.json
@@ -1,0 +1,15 @@
+{
+  "name": "Adafruit_VEML6070",
+  "keywords": "sensor, UV, light",
+  "description": "Arduino library for VEML6070 UV light sensors",
+  "repository":
+  {
+    "type": "git",
+    "url": "https://github.com/adafruit/Adafruit_VEML6070.git"
+  },
+  "frameworks": "arduino",
+  "platforms": [
+    "atmelavr",
+    "espressif"
+  ]
+}


### PR DESCRIPTION
No code change!

Adds plateformio (pio) library description (submitted after pull request).
Inspired by Adafruit_BME280 already in pio with reference number  166.

```
[ 166 ] Adafruit_BME280  arduino, atmelavr     "Adafruit Industries": Arduino library for BME280 humidity and pressure sensors

```

Also adds readme linking to Adafruit (product and learn)

Thanks for all your work 
I do not pretend to be a great help ... but this PR will help people integrate your code easily.
Hope you'll merge it.
