### PR TITLE
Please include sleep functionality of VEML6070

### DIFF
--- a/Adafruit_VEML6070.cpp
+++ b/Adafruit_VEML6070.cpp
@@ -29,7 +29,7 @@ void Adafruit_VEML6070::begin(veml6070_integrationtime_t itime) {
   Wire.begin();
   Wire.beginTransmission(VEML6070_ADDR_L);
   this->config=((itime << 2) | 0x02);
-  Wire.write(config);
+  Wire.write(this->config);
   Wire.endTransmission();
   delay(500);
 }

--- a/Adafruit_VEML6070.cpp
+++ b/Adafruit_VEML6070.cpp
@@ -25,9 +25,11 @@
 
 
 void Adafruit_VEML6070::begin(veml6070_integrationtime_t itime) {
+  
   Wire.begin();
   Wire.beginTransmission(VEML6070_ADDR_L);
-  Wire.write((itime << 2) | 0x02);
+  this->config=((itime << 2) | 0x02);
+  Wire.write(config);
   Wire.endTransmission();
   delay(500);
 }
@@ -42,3 +44,15 @@ uint16_t Adafruit_VEML6070::readUV() {
   return uvi;  
 }
 
+void Adafruit_VEML6070::sleep(bool mode) {
+
+	if (mode) 
+		this->config |= 1; // Go to sleep			
+	else 
+		this->config &= 254; // Wake up
+	
+  Wire.beginTransmission(VEML6070_ADDR_L);
+  Wire.write(this->config);
+  Wire.endTransmission();
+  delay(500);
+}

--- a/Adafruit_VEML6070.h
+++ b/Adafruit_VEML6070.h
@@ -39,6 +39,8 @@ class Adafruit_VEML6070 {
   Adafruit_VEML6070() {};
 
   void begin(veml6070_integrationtime_t itime);
+  void sleep(bool mode);
   uint16_t readUV(void);
  private:
+  byte config;
 };


### PR DESCRIPTION
Hi,

I'm proposing to expand the library to include the sleep functionality of the VEML6070 module.

I'm working on a battery powered device which includes the VEML6070. I measured the consumption to be aproxaimtely 60 uA constant - not too high but it can't be reduced by using the sleep mode in the chip.

I created a function sleep(mode) - mode = true puts the module to sleep, while mode = false wakes it up.

The config register can't be read so the config byte needs to be stored in a variable, which is then modified and re-written to the register after every change.

I hope this contribution is well received!

Manuel