### PR TITLE
Feature/multi i2c

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.development

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ before_install:
 install:
    - arduino --install-library "Adafruit ILI9341"
    - arduino --install-library "AUnit"
+   - arduino --install-library "SoftWire"
 
 script:
    - build_main_platforms

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ install:
    - arduino --install-library "Adafruit ILI9341"
    - arduino --install-library "AUnit"
    - arduino --install-library "SoftWire"
+   - arduino --install-library "AsyncDelay"
 
 script:
    - build_main_platforms

--- a/Adafruit_VEML6070.cpp
+++ b/Adafruit_VEML6070.cpp
@@ -44,24 +44,10 @@
 */
 /**************************************************************************/
 template <class I2C>
-Adafruit_VEML6070<I2C>::Adafruit_VEML6070(TwoWire *i2c) {
+Adafruit_VEML6070<I2C>::Adafruit_VEML6070(I2C *i2c) {
     //default setting
     _commandRegister.reg = 0x02;
-    _i2c = (I2C*) i2c;          // Type matching of function makes this safe
-    _i2cType = TWOWIRE;
-}
-
-/**************************************************************************/
-/*! 
-    @brief constructor initializes default configuration value
-*/
-/**************************************************************************/
-template <class I2C>
-Adafruit_VEML6070<I2C>::Adafruit_VEML6070(SoftWire *i2c) {
-    //default setting
-    _commandRegister.reg = 0x02;
-    _i2c = (I2C*) i2c;          // Type matching of function makes this safe
-    _i2cType = SOFTWIRE;
+    _i2c = i2c;          // Type matching of function makes this safe
 }
 
 /**************************************************************************/

--- a/Adafruit_VEML6070.cpp
+++ b/Adafruit_VEML6070.cpp
@@ -89,7 +89,13 @@ void Adafruit_VEML6070::setInterrupt(bool state, bool level) {
 /**************************************************************************/
 bool Adafruit_VEML6070::clearAck() {
   _i2c->begin();
-  return _i2c->requestFrom(VEML6070_ADDR_ARA, 1);
+  bool ret = _i2c->requestFrom(VEML6070_ADDR_ARA, 1);
+
+  #ifdef _DEBUG_
+    if (ret) { Serial.println("\nACK cleared\n"); }
+  #endif
+
+  return ret;
 }
 
 /**************************************************************************/

--- a/Adafruit_VEML6070.cpp
+++ b/Adafruit_VEML6070.cpp
@@ -41,6 +41,7 @@
 /**************************************************************************/
 /*! 
     @brief constructor initializes default configuration value
+    @param i2c Required pointer to TwoWire or SoftWire object. e.g. &Wire
 */
 /**************************************************************************/
 template <class I2C>
@@ -54,7 +55,6 @@ Adafruit_VEML6070<I2C>::Adafruit_VEML6070(I2C *i2c) {
 /*! 
     @brief  setup and initialize communication with the hardware
     @param itime the integration time to use for the data
-    @param twoWire Optional pointer to the desired TwoWire I2C object. Defaults to &Wire
 */
 /**************************************************************************/
 template <class I2C>
@@ -167,5 +167,7 @@ void Adafruit_VEML6070<I2C>::writeCommand() {
   _i2c->endTransmission();
 }
 
+// Required to let the compiler know which templates to build, 
+// allowing template functions to be defined outside the header file (here).
 template class Adafruit_VEML6070<TwoWire>;
 template class Adafruit_VEML6070<SoftWire>;

--- a/Adafruit_VEML6070.cpp
+++ b/Adafruit_VEML6070.cpp
@@ -44,9 +44,24 @@
 */
 /**************************************************************************/
 template <class I2C>
+Adafruit_VEML6070<I2C>::Adafruit_VEML6070(TwoWire *i2c) {
     //default setting
     _commandRegister.reg = 0x02;
+    _i2c = (I2C*) i2c;          // Type matching of function makes this safe
+    _i2cType = TWOWIRE;
+}
 
+/**************************************************************************/
+/*! 
+    @brief constructor initializes default configuration value
+*/
+/**************************************************************************/
+template <class I2C>
+Adafruit_VEML6070<I2C>::Adafruit_VEML6070(SoftWire *i2c) {
+    //default setting
+    _commandRegister.reg = 0x02;
+    _i2c = (I2C*) i2c;          // Type matching of function makes this safe
+    _i2cType = SOFTWIRE;
 }
 
 /**************************************************************************/
@@ -57,6 +72,7 @@ template <class I2C>
 */
 /**************************************************************************/
 template <class I2C>
+void Adafruit_VEML6070<I2C>::begin(veml6070_integrationtime_t itime) {
   _commandRegister.bit.IT = itime;
 
   clearAck();
@@ -166,3 +182,4 @@ void Adafruit_VEML6070<I2C>::writeCommand() {
 }
 
 template class Adafruit_VEML6070<TwoWire>;
+template class Adafruit_VEML6070<SoftWire>;

--- a/Adafruit_VEML6070.cpp
+++ b/Adafruit_VEML6070.cpp
@@ -42,7 +42,8 @@
     @brief constructor initializes default configuration value
 */
 /**************************************************************************/
-Adafruit_VEML6070::Adafruit_VEML6070() {
+template <class I2C>
+Adafruit_VEML6070<I2C>::Adafruit_VEML6070() {
     //default setting
     _commandRegister.reg = 0x02;
 }
@@ -54,7 +55,8 @@ Adafruit_VEML6070::Adafruit_VEML6070() {
     @param twoWire Optional pointer to the desired TwoWire I2C object. Defaults to &Wire
 */
 /**************************************************************************/
-void Adafruit_VEML6070::begin(veml6070_integrationtime_t itime, TwoWire *twoWire) {
+template <class I2C>
+void Adafruit_VEML6070<I2C>::begin(veml6070_integrationtime_t itime, I2C *twoWire) {
   _i2c = twoWire;
 
   _commandRegister.bit.IT = itime;
@@ -70,7 +72,8 @@ void Adafruit_VEML6070::begin(veml6070_integrationtime_t itime, TwoWire *twoWire
     @param  level 1 for threshold value of 145, 0 for 102 (default)
 */
 /**************************************************************************/
-void Adafruit_VEML6070::setInterrupt(bool state, bool level) {
+template <class I2C>
+void Adafruit_VEML6070<I2C>::setInterrupt(bool state, bool level) {
   _commandRegister.bit.ACK = state;
   _commandRegister.bit.ACK_THD = level;
 
@@ -87,7 +90,8 @@ void Adafruit_VEML6070::setInterrupt(bool state, bool level) {
     @return True if ACK was active (interrupt triggered)
 */
 /**************************************************************************/
-bool Adafruit_VEML6070::clearAck() {
+template <class I2C>
+bool Adafruit_VEML6070<I2C>::clearAck() {
   _i2c->begin();
   bool ret = _i2c->requestFrom(VEML6070_ADDR_ARA, 1);
 
@@ -104,7 +108,8 @@ bool Adafruit_VEML6070::clearAck() {
     @return the UV reading as a 16 bit integer
 */
 /**************************************************************************/
-uint16_t Adafruit_VEML6070::readUV() {
+template <class I2C>
+uint16_t Adafruit_VEML6070<I2C>::readUV() {
   waitForNext();
 
   if (_i2c->requestFrom(VEML6070_ADDR_H, 1) != 1) return -1;
@@ -121,7 +126,8 @@ uint16_t Adafruit_VEML6070::readUV() {
     @brief  wait for one integration period (with ~10% clock error margin)
 */
 /**************************************************************************/
-void Adafruit_VEML6070::waitForNext() {
+template <class I2C>
+void Adafruit_VEML6070<I2C>::waitForNext() {
   // Map the integration time code to the correct multiple (datasheet p. 8)
   // {0 -> 1, 1 -> 2; 2 -> 4; 3 -> 8}
   uint8_t itCount = 1;
@@ -140,7 +146,8 @@ void Adafruit_VEML6070::waitForNext() {
     @param state true to enter sleep mode, false to exit
 */
 /**************************************************************************/
-void Adafruit_VEML6070::sleep(bool state) {
+template <class I2C>
+void Adafruit_VEML6070<I2C>::sleep(bool state) {
   _commandRegister.bit.SD = state;
 
   writeCommand();
@@ -152,9 +159,12 @@ void Adafruit_VEML6070::sleep(bool state) {
     @brief write current internal _commandRegister value to device
 */
 /**************************************************************************/
-void Adafruit_VEML6070::writeCommand() {
+template <class I2C>
+void Adafruit_VEML6070<I2C>::writeCommand() {
   _i2c->begin();
   _i2c->beginTransmission(VEML6070_ADDR_L);
   _i2c->write(_commandRegister.reg);
   _i2c->endTransmission();
 }
+
+template class Adafruit_VEML6070<TwoWire>;

--- a/Adafruit_VEML6070.cpp
+++ b/Adafruit_VEML6070.cpp
@@ -34,6 +34,7 @@
  #include "WProgram.h"
 #endif
 #include "Wire.h"
+#include "SoftWire.h"     // SoftWire is available from Arduino Library Manager
 
 #include "Adafruit_VEML6070.h"
 
@@ -43,9 +44,9 @@
 */
 /**************************************************************************/
 template <class I2C>
-Adafruit_VEML6070<I2C>::Adafruit_VEML6070() {
     //default setting
     _commandRegister.reg = 0x02;
+
 }
 
 /**************************************************************************/
@@ -56,9 +57,6 @@ Adafruit_VEML6070<I2C>::Adafruit_VEML6070() {
 */
 /**************************************************************************/
 template <class I2C>
-void Adafruit_VEML6070<I2C>::begin(veml6070_integrationtime_t itime, I2C *twoWire) {
-  _i2c = twoWire;
-
   _commandRegister.bit.IT = itime;
 
   clearAck();

--- a/Adafruit_VEML6070.h
+++ b/Adafruit_VEML6070.h
@@ -24,10 +24,9 @@
 #endif
 #include "Wire.h"
 
-// really unusual way of getting data, your read from two different addrs!
 
-#define VEML6070_ADDR_H     (0x39) ///< High address
-#define VEML6070_ADDR_L     (0x38) ///< Low address
+#define VEML6070_ADDR_H     (0x39) ///< High measurement byte address
+#define VEML6070_ADDR_L     (0x38) ///< Low measurement byte & command address
 #define VEML6070_ADDR_ARA   (0x0C) ///< Alert Resp Address (read to clear condition)
 
 #define _DEBUG_                    ///< Enables serial output for troubleshooting
@@ -50,11 +49,12 @@ typedef enum veml6070_integrationtime {
     @brief  Class that stores state and functions for interacting with VEML6070 sensor IC
 */
 /**************************************************************************/
+template <class I2C>
 class Adafruit_VEML6070 {
  public:
   Adafruit_VEML6070();
 
-  void begin(veml6070_integrationtime_t itime, TwoWire *twoWire = &Wire);
+  void begin(veml6070_integrationtime_t itime, I2C *twoWire = &Wire);
   void setInterrupt(bool state, bool level = 0);
   bool clearAck();
   uint16_t readUV(void);
@@ -62,7 +62,7 @@ class Adafruit_VEML6070 {
   void sleep(bool state);
  private:
   void writeCommand(void);
-  TwoWire *_i2c;
+  I2C *_i2c;
 
   typedef union {
     struct {

--- a/Adafruit_VEML6070.h
+++ b/Adafruit_VEML6070.h
@@ -53,8 +53,7 @@ typedef enum veml6070_integrationtime {
 template <class I2C>
 class Adafruit_VEML6070 {
  public:
-  Adafruit_VEML6070(TwoWire *i2c);
-  Adafruit_VEML6070(SoftWire *i2c);
+  Adafruit_VEML6070(I2C *i2c);
 
   void begin(veml6070_integrationtime_t itime);
   void setInterrupt(bool state, bool level = 0);

--- a/Adafruit_VEML6070.h
+++ b/Adafruit_VEML6070.h
@@ -23,6 +23,7 @@
  #include "WProgram.h"
 #endif
 #include "Wire.h"
+#include "SoftWire.h"
 
 
 #define VEML6070_ADDR_H     (0x39) ///< High measurement byte address
@@ -52,9 +53,10 @@ typedef enum veml6070_integrationtime {
 template <class I2C>
 class Adafruit_VEML6070 {
  public:
-  Adafruit_VEML6070();
+  Adafruit_VEML6070(TwoWire *i2c);
+  Adafruit_VEML6070(SoftWire *i2c);
 
-  void begin(veml6070_integrationtime_t itime, I2C *twoWire = &Wire);
+  void begin(veml6070_integrationtime_t itime);
   void setInterrupt(bool state, bool level = 0);
   bool clearAck();
   uint16_t readUV(void);
@@ -63,6 +65,13 @@ class Adafruit_VEML6070 {
  private:
   void writeCommand(void);
   I2C *_i2c;
+
+  typedef enum veml6070_i2c_lib {
+    TWOWIRE,
+    SOFTWIRE
+  } veml6070_i2c_lib_t;
+
+  veml6070_i2c_lib_t _i2cType;
 
   typedef union {
     struct {

--- a/Adafruit_VEML6070.h
+++ b/Adafruit_VEML6070.h
@@ -65,13 +65,6 @@ class Adafruit_VEML6070 {
   void writeCommand(void);
   I2C *_i2c;
 
-  typedef enum veml6070_i2c_lib {
-    TWOWIRE,
-    SOFTWIRE
-  } veml6070_i2c_lib_t;
-
-  veml6070_i2c_lib_t _i2cType;
-
   typedef union {
     struct {
       uint8_t SD:1;

--- a/Adafruit_VEML6070.h
+++ b/Adafruit_VEML6070.h
@@ -30,6 +30,7 @@
 #define VEML6070_ADDR_L     (0x38) ///< Low address
 #define VEML6070_ADDR_ARA   (0x0C) ///< Alert Resp Address (read to clear condition)
 
+#define _DEBUG_                    ///< Enables serial output for troubleshooting
 
 /**************************************************************************/
 /*! 

--- a/examples/unittests/unittests.ino
+++ b/examples/unittests/unittests.ino
@@ -12,13 +12,13 @@
 #include <Adafruit_VEML6070.h>
 #include <AUnitVerbose.h>
 
-//#define USE_SOFTWIRE
+#define USE_SOFTWIRE      // Comment to use core Wire.h. Test #3 will hang.
 
 // Pin assignments
 #define POWER_PIN (11)
 #define ACK_PIN   (13)    // Blue LED on weakly when ACK is *not* set
 
-// Globals
+// Globals, conditional on I2C library used.
 #ifndef USE_SOFTWIRE
   Adafruit_VEML6070<TwoWire> uv = Adafruit_VEML6070<TwoWire>(&Wire);
 #else
@@ -29,11 +29,14 @@
 #endif
 
 
+// Checks whether I2C bus is clear
 bool i2c_ready(){ 
   return (digitalRead(SDA) == HIGH) && (digitalRead(SCL) == HIGH);
 }
 
 
+// Power-cycles the VEML6070, pulling the I2C lines low
+// to ensure it's fully powered down
 bool reset_state() {  
   pinMode(POWER_PIN, OUTPUT);
   digitalWrite(POWER_PIN, LOW);
@@ -42,9 +45,9 @@ bool reset_state() {
   pinMode(SCL, OUTPUT);
   digitalWrite(SCL, LOW);
 
-  delay(1000);
+  delay(100);
 
-  // Require I2C bus to be clear
+  // Require I2C bus to be clear. Wire.begin() will restore pull-ups
   pinMode(SDA, INPUT);
   pinMode(SCL, INPUT);
   digitalWrite(POWER_PIN, HIGH);
@@ -126,7 +129,7 @@ test(3_read_with_power_cycles) {
     uint16_t value = uv.readUV();
     Serial.print("UV: ");
     Serial.println(value);
-    //assertNotEqual(value, (uint16_t) 0xFFFF);
+    assertNotEqual(value, (uint16_t) 0xFFFF);
     assertNotEqual(value, (uint16_t) 0);
 
     assertTrue(reset_state());

--- a/examples/unittests/unittests.ino
+++ b/examples/unittests/unittests.ino
@@ -46,7 +46,6 @@ bool reset_state() {
   // Require I2C bus to be clear
   pinMode(SDA, INPUT);
   pinMode(SCL, INPUT);
-  Wire.begin(); // Sets pullups on SDA and SCL
   digitalWrite(POWER_PIN, HIGH);
   delay(100);
   if (digitalRead(ACK_PIN) == LOW) {
@@ -116,7 +115,7 @@ test(2_interrupt) {
   if (!state) { skip(); } // Don't mark as success if we didn't trigger interrupt
 }
 
-/*
+
 test(3_read_with_power_cycles) {
   for (uint16_t i = 0; i < 10; i++) {
 
@@ -126,13 +125,13 @@ test(3_read_with_power_cycles) {
     uint16_t value = uv.readUV();
     Serial.print("UV: ");
     Serial.println(value);
-    assertNotEqual(value, (uint16_t) 0xFFFF);
+    //assertNotEqual(value, (uint16_t) 0xFFFF);
     assertNotEqual(value, (uint16_t) 0);
 
     assertTrue(reset_state());
   }
 }
-*/
+
 
 
 void setup() {

--- a/examples/unittests/unittests.ino
+++ b/examples/unittests/unittests.ino
@@ -12,8 +12,8 @@
 #include <AUnitVerbose.h>
 
 // Pin assignments
-#define POWER_PIN (13)
-#define ACK_PIN   (11)
+#define POWER_PIN (11)
+#define ACK_PIN   (13)    // Blue LED on weakly when ACK is *not* set
 
 // Globals
 Adafruit_VEML6070 uv = Adafruit_VEML6070();
@@ -33,10 +33,6 @@ bool reset_state() {
   digitalWrite(SCL, LOW);
 
   delay(1000);
-  
-  if (digitalRead(ACK_PIN) == LOW) {
-    Serial.println("ACK is set, expect problems...");
-  }
 
   // Require I2C bus to be clear
   pinMode(SDA, INPUT);
@@ -44,6 +40,9 @@ bool reset_state() {
   Wire.begin(); // Sets pullups on SDA and SCL
   digitalWrite(POWER_PIN, HIGH);
   delay(100);
+  if (digitalRead(ACK_PIN) == LOW) {
+    Serial.println("ACK is set, expect problems...");
+  }
   if (!i2c_ready()) { Serial.println("I2C bus locked after power cycle"); }
   return i2c_ready();
 }

--- a/examples/unittests/unittests.ino
+++ b/examples/unittests/unittests.ino
@@ -18,7 +18,15 @@
 
 // Globals
 //Adafruit_VEML6070<TwoWire> uv = Adafruit_VEML6070<TwoWire>(&Wire);
-Adafruit_VEML6070<SoftWire> uv = Adafruit_VEML6070<SoftWire>(&SoftWire(SDA, SCL));
+
+
+#define BUFFER_LENGTH   1
+uint8_t i2cBuf[BUFFER_LENGTH] = {0};
+SoftWire i2c(SDA, SCL);
+
+
+Adafruit_VEML6070<SoftWire> uv = Adafruit_VEML6070<SoftWire>(&i2c);
+
 
 bool i2c_ready(){ 
   return (digitalRead(SDA) == HIGH) && (digitalRead(SCL) == HIGH);
@@ -129,8 +137,12 @@ test(3_read_with_power_cycles) {
 
 void setup() {
   delay(1000); // wait for stability on some boards to prevent garbage Serial
-  Serial.begin(115200);
+  Serial.begin(9600);
   while(!Serial); // for the Arduino Leonardo/Micro only
+
+  i2c.setRxBuffer(i2cBuf, BUFFER_LENGTH);
+  i2c.setTxBuffer(i2cBuf, BUFFER_LENGTH);
+  i2c.setTimeout_ms(10);
 
   pinMode(POWER_PIN, OUTPUT);
   digitalWrite(POWER_PIN, HIGH);

--- a/examples/unittests/unittests.ino
+++ b/examples/unittests/unittests.ino
@@ -16,7 +16,7 @@
 #define ACK_PIN   (13)    // Blue LED on weakly when ACK is *not* set
 
 // Globals
-Adafruit_VEML6070 uv = Adafruit_VEML6070();
+Adafruit_VEML6070<TwoWire> uv = Adafruit_VEML6070<TwoWire>();
 
 
 bool i2c_ready(){
@@ -107,7 +107,7 @@ test(2_interrupt) {
   if (!state) { skip(); } // Don't mark as success if we didn't trigger interrupt
 }
 
-
+/*
 test(3_read_with_power_cycles) {
   for (uint16_t i = 0; i < 10; i++) {
 
@@ -123,6 +123,8 @@ test(3_read_with_power_cycles) {
     assertTrue(reset_state());
   }
 }
+*/
+
 
 void setup() {
   delay(1000); // wait for stability on some boards to prevent garbage Serial

--- a/examples/unittests/unittests.ino
+++ b/examples/unittests/unittests.ino
@@ -12,20 +12,21 @@
 #include <Adafruit_VEML6070.h>
 #include <AUnitVerbose.h>
 
+//#define USE_SOFTWIRE
+
 // Pin assignments
 #define POWER_PIN (11)
 #define ACK_PIN   (13)    // Blue LED on weakly when ACK is *not* set
 
 // Globals
-//Adafruit_VEML6070<TwoWire> uv = Adafruit_VEML6070<TwoWire>(&Wire);
-
-
-#define BUFFER_LENGTH   1
-uint8_t i2cBuf[BUFFER_LENGTH] = {0};
-SoftWire i2c(SDA, SCL);
-
-
-Adafruit_VEML6070<SoftWire> uv = Adafruit_VEML6070<SoftWire>(&i2c);
+#ifndef USE_SOFTWIRE
+  Adafruit_VEML6070<TwoWire> uv = Adafruit_VEML6070<TwoWire>(&Wire);
+#else
+  #define BUFFER_LENGTH   1
+  uint8_t i2cBuf[BUFFER_LENGTH] = {0};
+  SoftWire i2c(SDA, SCL);
+  Adafruit_VEML6070<SoftWire> uv = Adafruit_VEML6070<SoftWire>(&i2c);
+#endif
 
 
 bool i2c_ready(){ 
@@ -139,9 +140,11 @@ void setup() {
   Serial.begin(9600);
   while(!Serial); // for the Arduino Leonardo/Micro only
 
+#ifdef USE_SOFTWIRE
   i2c.setRxBuffer(i2cBuf, BUFFER_LENGTH);
   i2c.setTxBuffer(i2cBuf, BUFFER_LENGTH);
   i2c.setTimeout_ms(10);
+#endif
 
   pinMode(POWER_PIN, OUTPUT);
   digitalWrite(POWER_PIN, HIGH);

--- a/examples/unittests/unittests.ino
+++ b/examples/unittests/unittests.ino
@@ -8,6 +8,7 @@
 
 
 #include <Wire.h>
+#include <SoftWire.h>
 #include <Adafruit_VEML6070.h>
 #include <AUnitVerbose.h>
 
@@ -16,10 +17,10 @@
 #define ACK_PIN   (13)    // Blue LED on weakly when ACK is *not* set
 
 // Globals
-Adafruit_VEML6070<TwoWire> uv = Adafruit_VEML6070<TwoWire>();
+//Adafruit_VEML6070<TwoWire> uv = Adafruit_VEML6070<TwoWire>(&Wire);
+Adafruit_VEML6070<SoftWire> uv = Adafruit_VEML6070<SoftWire>(&SoftWire(SDA, SCL));
 
-
-bool i2c_ready(){
+bool i2c_ready(){ 
   return (digitalRead(SDA) == HIGH) && (digitalRead(SCL) == HIGH);
 }
 

--- a/examples/vemltest/vemltest.ino
+++ b/examples/vemltest/vemltest.ino
@@ -1,7 +1,7 @@
 #include <Wire.h>
 #include "Adafruit_VEML6070.h"
 
-Adafruit_VEML6070 uv = Adafruit_VEML6070();
+Adafruit_VEML6070<TwoWire> uv = Adafruit_VEML6070<TwoWire>(&Wire);
 
 void setup() {
   Serial.begin(9600);

--- a/examples/vemltest_initbug/vemltest_initbug.ino
+++ b/examples/vemltest_initbug/vemltest_initbug.ino
@@ -21,7 +21,7 @@ void setup() {
 bool testAck() {
   bool ack = (digitalRead(ACK_PIN) == LOW);
   if (ack) { Serial.println("ACK is set (low)"); Serial.flush(); }
-  retutrn ack;
+  return ack;
 }
 
 bool i2c_ready(){

--- a/examples/vemltest_initbug/vemltest_initbug.ino
+++ b/examples/vemltest_initbug/vemltest_initbug.ino
@@ -5,7 +5,7 @@
 #define POWER_PIN (11)    
 #define ACK_PIN   (13)  // Note blue LED will turn *off* if ACK is set
 
-Adafruit_VEML6070 uv = Adafruit_VEML6070();
+Adafruit_VEML6070<TwoWire> uv = Adafruit_VEML6070<TwoWire>();
 
 void setup() {
   Serial.begin(115200);

--- a/examples/vemltest_initbug/vemltest_initbug.ino
+++ b/examples/vemltest_initbug/vemltest_initbug.ino
@@ -21,6 +21,7 @@ void setup() {
 bool testAck() {
   bool ack = (digitalRead(ACK_PIN) == LOW);
   if (ack) { Serial.println("ACK is set (low)"); Serial.flush(); }
+  retutrn ack;
 }
 
 bool i2c_ready(){

--- a/examples/vemltest_initbug/vemltest_initbug.ino
+++ b/examples/vemltest_initbug/vemltest_initbug.ino
@@ -5,10 +5,10 @@
 #define POWER_PIN (11)    
 #define ACK_PIN   (13)  // Note blue LED will turn *off* if ACK is set
 
-Adafruit_VEML6070<TwoWire> uv = Adafruit_VEML6070<TwoWire>();
+Adafruit_VEML6070<TwoWire> uv = Adafruit_VEML6070<TwoWire>(&Wire);
 
 void setup() {
-  Serial.begin(115200);
+  Serial.begin(9600);
   Serial.println("VEML6070 Test to Reveal Bug");
   
   pinMode(POWER_PIN, OUTPUT);

--- a/examples/vemltest_initbug/vemltest_initbug.ino
+++ b/examples/vemltest_initbug/vemltest_initbug.ino
@@ -1,0 +1,65 @@
+#include <Wire.h>
+#include <Adafruit_VEML6070.h>
+
+// Pin assignments
+#define POWER_PIN (11)    
+#define ACK_PIN   (13)  // Note blue LED will turn *off* if ACK is set
+
+Adafruit_VEML6070 uv = Adafruit_VEML6070();
+
+void setup() {
+  Serial.begin(115200);
+  Serial.println("VEML6070 Test to Reveal Bug");
+  
+  pinMode(POWER_PIN, OUTPUT);
+  digitalWrite(POWER_PIN, LOW);
+  
+  digitalWrite(ACK_PIN, INPUT_PULLUP);  // ACK is open-drain
+
+}
+
+bool testAck() {
+  bool ack = (digitalRead(ACK_PIN) == LOW);
+  if (ack) { Serial.println("ACK is set (low)"); Serial.flush(); }
+}
+
+bool i2c_ready(){
+  bool ready = (digitalRead(SDA) == HIGH) && (digitalRead(SCL) == HIGH);
+  if (!ready) { Serial.println("I2C bus locked"); Serial.flush(); }
+  return ready;
+}
+
+void loop() {
+  // Power DOWN the VEML 6070, and drive the I2C bus
+  // to ground to ensure the sensor is actually power-cycled
+  digitalWrite(POWER_PIN, LOW);
+  pinMode(SDA, OUTPUT);
+  digitalWrite(SDA, LOW);
+  pinMode(SCL, OUTPUT);
+  digitalWrite(SCL, LOW);
+  pinMode(SDA, INPUT);
+  pinMode(SCL, INPUT);
+  delay(100);
+  
+  
+  // Power up and initialize the VEML 6070
+  digitalWrite(POWER_PIN, HIGH);
+  Wire.begin();
+  delay(1000);  // For device to power up
+
+  i2c_ready();
+  testAck();
+  //if (uv.clearAck()) { Serial.println("Ack was set"); Serial.flush(); }
+  i2c_ready();
+
+  Serial.print("init.. "); Serial.flush();
+  uv.begin(VEML6070_HALF_T);
+  Serial.println("done");
+
+
+  // Attempt to read the UV value after allowing for measurement delay
+  Serial.print("UV: ");
+  uint16_t value = uv.readUV();
+  Serial.println(value);
+}
+

--- a/examples/vemltest_softwire/vemltest_softwire.ino
+++ b/examples/vemltest_softwire/vemltest_softwire.ino
@@ -1,0 +1,42 @@
+// This variant on the test example shows how to use
+// the SoftWire library instead of the Wire library. 
+
+// Some extra initialization is required, including 
+// creating an external 1-byte i2c buffer; it can be
+// just 1 byte, and shared between TX and RX, because
+// we're really using the SMBus protocol and only ever
+// reading or writing 1 byte in atomic operations.
+
+// The benefit of using the SoftWire library is that it
+// uses timeouts so it will never hang your code, and 
+// it does not experience bus lockups if the VEML6070's
+// power is cycled. See unittests for example where 
+// this is needed.
+
+#include <SoftWire.h>
+#include "Adafruit_VEML6070.h"
+
+
+#define BUFFER_LENGTH   1
+uint8_t i2cBuf[BUFFER_LENGTH] = {0};
+SoftWire i2c(SDA, SCL);
+Adafruit_VEML6070<SoftWire> uv = Adafruit_VEML6070<SoftWire>(&i2c);
+
+
+void setup() {
+  Serial.begin(9600);
+  Serial.println("VEML6070 Test");
+
+  i2c.setRxBuffer(i2cBuf, BUFFER_LENGTH);
+  i2c.setTxBuffer(i2cBuf, BUFFER_LENGTH);
+  i2c.setTimeout_ms(10);
+  
+  uv.begin(VEML6070_1_T);  // pass in the integration time constant
+}
+
+
+void loop() {
+  Serial.print("UV light level: "); Serial.println(uv.readUV());
+  
+  delay(1000);
+}

--- a/library.properties
+++ b/library.properties
@@ -1,4 +1,4 @@
-name=Adafruit VEML6070 Library
+name=Adafruit VEML6070
 version=1.0.1
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>


### PR DESCRIPTION
These changes were made to address failure scenarios if/when the Wire library causes the Arduino to hang due to bus conditions. In particular, a reproducible problem is a hang after the VEML6070's power is cycled, which is shown in unit tests. 

**Summary of changes:**
-Adafruit_VEML6070 class is now templated to use either Wire or SoftWire as I2C library
-Minor edits to the vemltest example allow it to work as before
-A functionally equivalent example, vemltest_softwire, was created to demonstrate initialization requirements of the SoftWire library
-The unit test sketch has a single #define switch for which I2C library is used, and an additional unit test that will hang when the Wire library is used but not when SoftWire is used.

**Limitations:** It's still possible to get an Arduino into a reset loop under certain bad VEML6070 power conditions.

**Validation:** Included unit test sketch, and Travis-CI builds all worked


I get that this is rocking the boat for code that is meant to be as easy as possible for beginners. My goal is for this solution to be as widely available as possible, so let me know if there are changes that would make it possible to say yes to integrating this, if that's not already the case. 
The constraints are that Arduino Wire has been broken for years without adopting a solution, and Steve Marple is happy with his decisions on the SoftWire interface.

Thanks to @stevemarple for advice on the templating approach.